### PR TITLE
Add react-atoms as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "radium": "^0.18.1",
-    "ramda": "^0.22.1"
+    "ramda": "^0.22.1",
+    "react-atoms": "^2.0.10"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",


### PR DESCRIPTION
When using this in a project, I'm getting the following error:

```
Error in ./~/react-object/lib/components/Value.js
Module not found: 'react-atoms/components/Twisty' in /webdev/project/node_modules/react-object/lib/components
```

Seems like you forgot to declare `react-atoms` in your dependency list.